### PR TITLE
Already opened file detection + cleanup on tab close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.1 (02/09/2017)
+
+* Clean up localFiles on tab close
+* Avoid using timestamp on local file name so already opened files are detected
+
+## ...
+
 ## 1.7.0
 * Convert package to conform to Atom 1.0 API
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,6 @@
  - [x] Store when files are downloaded
  - [ ] Handle SFTP "expected" errors like PERMISSION_DENIED when navigating
  - [ ] Add a "Remote File Modified" warning based on timestamp
+ - [ ] Split the file view into two: top Kate-like folder tree and bottom remote file browser
+ - [ ] Add a "Show in remote browser" context option on the folders in the above top view
+ - [ ] Clean this TODO

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -172,7 +172,7 @@ module.exports =
         host = Host.deserialize(JSON.parse(decodeURIComponent(query.host)))
 
         atom.project.bufferForPath(localFile.path).then (buffer) ->
-          params = {buffer: buffer, registerEditor: true, host: host, localFile: localFile}
+          params = {buffer: buffer, registerEditor: true, host: host, autoHeight: false, localFile: localFile}
           # copied from workspace.buildTextEditor
           ws = atom.workspace
           params = _.extend({

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -269,7 +269,7 @@ module.exports =
           @host.addLocalFile(localFile)
           uri = "remote-edit://localFile/?localFile=#{encodeURIComponent(JSON.stringify(localFile.serialize()))}&host=#{encodeURIComponent(JSON.stringify(localFile.host.serialize()))}"
           # Create the textEditor but also make sure we clean up on destroy
-          # and remove the loca file...
+          # and remove the local file...
           atom.workspace.open(uri, split: 'left').then(
             (textEditor) =>
               textEditor.onDidDestroy(() =>

--- a/lib/view/files-view.coffee
+++ b/lib/view/files-view.coffee
@@ -247,11 +247,17 @@ module.exports =
           if filePane
             filePaneItem = filePane.itemForURI(uri)
             filePane.activateItem(filePaneItem)
-            confirmResult = atom.confirm
-              message: 'Reopen this file?'
-              detailedMessage: 'Unsaved data will be lost.'
-              buttons: ['Yes','No']
+            # confirmResult = atom.confirm
+            #   message: 'Reopen this file?'
+            #   detailedMessage: 'Unsaved data will be lost.'
+            #   buttons: ['Yes','No']
             # confirmResult: Yes = 0, No = 1, Close button = 1
+            confirmResult = ElectronDialog.showMessageBox({
+                    title: "File Already Opened...",
+                    message: "Reopen this file? Unsaved changes will be lost",
+                    type: "warning",
+                    buttons: ["Yes", "No"]
+                })
             if confirmResult
               callback(null, null)
             else

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remote-edit2",
   "main": "./lib/main.coffee",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Browse and edit remote files using SFTP and FTP",
   "homepage": "https://github.com/duxet/remote-edit2",
   "repository": {


### PR DESCRIPTION
1. Removed the timestamp from the local filename/path so already opened files are detected. Previous version allowed a single remote file to be opened multiple times...

1. When using for long time, the configuration file (`remoteEdit.json`) has too many `localFiles`. This is mainly due to not cleaning up when the tabs are closed. Fixed it by cleaning up `onDidDestroy` when the tab is created from `openFile()`

UPDATE:

1. The default behavior has changed at some point in 1.19 (see https://github.com/atom/atom/issues/14811). The last commit fixes the scrolling issue